### PR TITLE
suggestion: some materials for ed-wg to provide

### DIFF
--- a/Education/Suggestions/prototyping-ideas-2022-02-16-.md
+++ b/Education/Suggestions/prototyping-ideas-2022-02-16-.md
@@ -1,0 +1,31 @@
+### Suggestions for Educational Working Group (prototyping ideas):
+
+* **Suggestion For Educational Materials (Internal Tooling):**
+
+	* Title: Curate & Create internal tooling resources (for Git & GitHub) for working group leads who do not have a technical background or who have not used Git & GitHub within teams before.
+	* Reason: This allows them to contribute to the central repo, provides a more organised global view of the progress made by each working group.
+	* Extra Information: 
+		
+		1. These resources wouldn't necessarily be for developers, they would be aimed at less technical or non-technical working groups.
+		2. Materials would be in written and video (tutorial) form.
+		3. Materials would demonstrate how to **navigate GitHub**.
+		4. Materials would demonstrate how to use **Git CLI - VERY BASIC**.
+		4. Materials would demonstrate how to **contribute to GitHub using GitHub**.
+		5. Materials would demonstrate how to **contribute to GitHub using Git CLI**.
+		6. Materials would provide an **insight into Pull Requests & how to collaborate using PRs**.
+		7. Materials would **encourage comments**.
+		8. Materials would **encourage reviews**.
+		9. Materials would **encourage feedback**.
+		10. Materials would not be aimed at technical individuals.
+		11. Materials would establish **very basic standards** (e.g. please don't push to master without opening a PR).
+
+* **Suggestion For Educational Materials (Curating Internal & External - DAOs):**
+
+	* Title: Creating an index for our current library & adding some additional materials to it.
+	* Reason: Make it easier to navigate our materials for:
+		
+		1. Newcomers to Crypto.
+		2. Intermediate without much knowledge of DAOs.
+		3. Intermediate with some knowledge of DAOs.
+		4. Builders / Developers who want to read up on current implementations that have already been deployed.
+		5. Researchers (Typically papers).


### PR DESCRIPTION
Two suggestions in terms of materials that the educational working group can provide. These suggestions serve two purposes:

1. To help organise project collaboration (and tracking) via Git & GitHub (aimed at non-technical or not as technical individuals).
2. To begin indexing our library of resources and make it easy to navigate and search through for different members.